### PR TITLE
Fix front show

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -31,3 +31,7 @@ body {
 .btn-primary {
   color: white;
 }
+
+.fas {
+  margin-right: 0.5rem;
+}

--- a/app/assets/stylesheets/cats.scss
+++ b/app/assets/stylesheets/cats.scss
@@ -64,7 +64,7 @@ i.fas.fa-paw {
 .owner-info {
   width: 80%;
   margin: 0 auto;
-  padding: 0r 1rem;
+  padding: 0 1rem;
 }
 
 .booking-price {

--- a/app/assets/stylesheets/cats.scss
+++ b/app/assets/stylesheets/cats.scss
@@ -1,10 +1,18 @@
-.cat-info .fa-paw {
+.cat-info .fas {
   font-size: 1.3rem;
-  i {
-    margin: 0 -3px;
-  }
 }
 
+i.fas.fa-paw {
+  margin-right: 0;
+  margin: 0 -2px;
+}
+
+.cat-info {
+  ul {
+    list-style: none;
+    padding: 0 0;
+  }
+}
 .cat-photos {
   position: relative;
 

--- a/app/assets/stylesheets/cats.scss
+++ b/app/assets/stylesheets/cats.scss
@@ -5,11 +5,6 @@
   }
 }
 
-.star {
-  display: inline;
-  font-size: 1rem;
-}
-
 .cat-photos {
   position: relative;
 
@@ -37,6 +32,9 @@
 .cat-show {
   width: 80%;
   margin: 0 auto;
+  h3 {
+    text-align: left;
+  }
 }
 
 .booking {

--- a/app/assets/stylesheets/cats.scss
+++ b/app/assets/stylesheets/cats.scss
@@ -58,13 +58,13 @@ i.fas.fa-paw {
   margin: 0 auto;
   padding: 1rem 1rem;
   border-radius: 15px;
-  box-shadow: (0 0 20px 1px) $lightgray;
+  box-shadow: (0 0 20px 1px)  #BBC4D1;
 }
 
 .owner-info {
   width: 80%;
   margin: 0 auto;
-  padding: 0 1rem;
+  padding: 0r 1rem;
 }
 
 .booking-price {

--- a/app/assets/stylesheets/cats.scss
+++ b/app/assets/stylesheets/cats.scss
@@ -11,6 +11,7 @@ i.fas.fa-paw {
   ul {
     list-style: none;
     padding: 0 0;
+    text-transform: capitalize;
   }
 }
 .cat-photos {
@@ -29,6 +30,13 @@ i.fas.fa-paw {
 .main-photo {
   height: 40vh;
   width: 95%;
+  object-fit: cover;
+  margin-bottom: 3vh;
+}
+
+.only-photo {
+  height: 40vh;
+  width: 100%;
   object-fit: cover;
   margin-bottom: 3vh;
 }
@@ -56,7 +64,7 @@ i.fas.fa-paw {
 .owner-info {
   width: 80%;
   margin: 0 auto;
-  padding: 1rem 1rem;
+  padding: 0 1rem;
 }
 
 .booking-price {

--- a/app/assets/stylesheets/cats.scss
+++ b/app/assets/stylesheets/cats.scss
@@ -54,7 +54,7 @@ i.fas.fa-paw {
 }
 
 .booking {
-  width: 80%;
+  width: 100%;
   margin: 0 auto;
   padding: 1rem 1rem;
   border-radius: 15px;
@@ -62,7 +62,7 @@ i.fas.fa-paw {
 }
 
 .owner-info {
-  width: 80%;
+  width: 100%;
   margin: 0 auto;
   padding: 0 1rem;
 }

--- a/app/assets/stylesheets/components/_cards.scss
+++ b/app/assets/stylesheets/components/_cards.scss
@@ -64,7 +64,6 @@
 
 .paw {
   padding-top: 8px;
-  width: 100%;
   text-align: right;
 }
 

--- a/app/javascript/components/photo_switch.js
+++ b/app/javascript/components/photo_switch.js
@@ -1,0 +1,18 @@
+const mainPhoto = document.querySelector('.main-photo');
+console.log(mainPhoto);
+const secondPhoto = document.querySelector('.second-photo');
+
+const switchPhotos = () => {
+  if (mainPhoto && secondPhoto) {
+    [mainPhoto, secondPhoto].forEach((item) => {
+      item.addEventListener('click', (event) => {
+        mainPhoto.classList.toggle("second-photo");
+        mainPhoto.classList.toggle("main-photo");
+        secondPhoto.classList.toggle("main-photo");
+        secondPhoto.classList.toggle("second-photo");
+      });
+    })
+  }
+};
+
+export { switchPhotos };

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -28,6 +28,7 @@ import { searchCards } from '../components/search';
 import { initMapbox } from '../plugins/init_mapbox';
 import { flatPickr } from "../plugins/flatpickr"
 import { updatePrice } from "../components/booking";
+import { switchPhotos } from "../components/photo_switch";
 // Internal imports, e.g:
 // import { initSelect2 } from '../components/init_select2';
 
@@ -38,4 +39,5 @@ document.addEventListener('turbolinks:load', () => {
   initMapbox();
   flatPickr();
   updatePrice();
+  switchPhotos();
 });

--- a/app/views/cats/show.html.erb
+++ b/app/views/cats/show.html.erb
@@ -26,16 +26,21 @@
         <div class="row">
           <div class="col">
            <ul>
-             <li><strong>Sexe : </strong><%= @cat.gender %></li>
-             <li><strong>Age : </strong><%= "#{@cat.age} an(s)" %></li>
-             <li><strong>Pelage : </strong><%= "#{@cat.color}, poil #{@cat.hair_length}"%></li>
+             <li><i class="fas fa-cat"></i><%= @cat.breed %>, <%= "#{@cat.color}, poil #{@cat.hair_length}"%></li>
+             <li><i class="fas fa-birthday-cake"></i><%= "#{@cat.age} an(s)" %></li>
            </ul>
           </div>
           <div class="col">
            <ul>
-             <li><strong>Castré : </strong><%= @cat.neutered == true ? "oui" : "non" %></li>
-             <li><strong>Régime : </strong><%= @cat.diet %></li>
-             <li><strong>Race : </strong><%= @cat.breed %></li>
+             <li>
+              <% if @cat.gender == "female" %>
+                <i class="fas fa-venus"></i>
+              <% else %>
+                <i class="fas fa-mars"></i>
+              <% end %>
+              <%= @cat.neutered == true ? "Castré(e)" : "Non castré(e)" %>
+            </li>
+             <li><i class="fas fa-utensils"></i><%= @cat.diet %></li>
            </ul>
           </div>
         </div>

--- a/app/views/cats/show.html.erb
+++ b/app/views/cats/show.html.erb
@@ -1,11 +1,15 @@
 <div class="cat-show bg-white my-3 p-4 rounded shadow">
-  <div class="row go-back mb-2">
+  <div class="go-back mb-2">
     <i class="fas fa-long-arrow-alt-left align-self-center text-primary mr-2"></i><%= link_to "Retourner aux résultats", request.referer.present? ? request.referer : root_path %>
   </div>
   <div class="row">
     <div class="col-12 col-md-6">
       <div class="cat-photos">
+        <% if !@cat.photos.attached? %>
+        <%= image_tag ["blue-cat.png", "pink-cat.png"].sample, class: "only-photo" %>
+        <% else %>
         <%= cl_image_tag @cat.photos.first.key , class: "main-photo" %>
+        <% end %>
         <% if @cat.photos.count > 1 %>
           <%= cl_image_tag @cat.photos[1].key , class: "second-photo" %>
         <% end %>
@@ -27,7 +31,7 @@
           <div class="col-8">
            <ul>
              <li><i class="fas fa-cat"></i><%= @cat.breed %>, <%= "#{@cat.color}, poil #{@cat.hair_length}"%></li>
-             <li><i class="fas fa-birthday-cake"></i><%= "#{@cat.age} an(s)" %></li>
+             <li><i class="fas fa-birthday-cake"></i><%= "#{@cat.age} an#{"s" if @cat.age > 1}" %></li>
            </ul>
           </div>
           <div class="col-4">

--- a/app/views/cats/show.html.erb
+++ b/app/views/cats/show.html.erb
@@ -24,21 +24,17 @@
       </div>
       <div class="cat-info">
         <div class="row">
-          <div class="col">
+          <div class="col-8">
            <ul>
              <li><i class="fas fa-cat"></i><%= @cat.breed %>, <%= "#{@cat.color}, poil #{@cat.hair_length}"%></li>
              <li><i class="fas fa-birthday-cake"></i><%= "#{@cat.age} an(s)" %></li>
            </ul>
           </div>
-          <div class="col">
+          <div class="col-4">
            <ul>
              <li>
-              <% if @cat.gender == "female" %>
-                <i class="fas fa-venus"></i>
-              <% else %>
-                <i class="fas fa-mars"></i>
-              <% end %>
-              <%= @cat.neutered == true ? "Castré(e)" : "Non castré(e)" %>
+              <i class="fas fa-<%= @cat.gender == "femelle" ? "venus" : "mars" %>"></i>
+              <%= @cat.neutered == true ? "castré" : "non castré" %><%= "e" if @cat.gender == "femelle" %>
             </li>
              <li><i class="fas fa-utensils"></i><%= @cat.diet %></li>
            </ul>
@@ -48,9 +44,9 @@
     </div>
     <div class="col-12 col-md-6">
       <div class="owner-info">
-        <p class="mb-0"><i class="fas fa-user"></i> Ce chat appartient à <%= @cat.user.first_name %></p>
-        <p class="mb-0"><i class="fas fa-map-marker-alt"></i> Vous pourrez le récupérer à <%= @cat.city %></p>
-        <p class="mb-0" id="price" data-price-per-half-day="<%= @cat.price_per_half_day %>" ><i class="fas fa-euro-sign"></i> <%= @cat.price_per_half_day %> / demi-journée</p>
+        <p class="mb-0"><i class="fas fa-user"></i>Ce chat appartient à <%= @cat.user.first_name %></p>
+        <p class="mb-0"><i class="fas fa-map-marker-alt"></i>Vous pourrez le récupérer à <%= @cat.city %></p>
+        <p class="mb-0" id="price" data-price-per-half-day="<%= @cat.price_per_half_day %>" ><i class="fas fa-euro-sign"></i><%= @cat.price_per_half_day %> / demi-journée</p>
       </div>
       <div class="booking mt-2">
         <%= render "components/booking", booking: @booking %>

--- a/app/views/cats/show.html.erb
+++ b/app/views/cats/show.html.erb
@@ -11,10 +11,8 @@
         <% end %>
       </div>
       <div class="row mb-2">
-        <div class="col-8">
+        <div class="col d-flex justify-content-between">
           <h3><strong><%= "#{@cat.name} " %></strong><%= "(#{@cat.tag})" %></h3>
-        </div>
-        <div class="col-4">
           <div class="paw">
             <i class="fas fa-paw"></i>
             <i class="fas fa-paw"></i>

--- a/app/views/cats/show.html.erb
+++ b/app/views/cats/show.html.erb
@@ -3,7 +3,7 @@
     <i class="fas fa-long-arrow-alt-left align-self-center text-primary mr-2"></i><%= link_to "Retourner aux résultats", request.referer.present? ? request.referer : root_path %>
   </div>
   <div class="row">
-    <div class="col-12 col-md-6">
+    <div class="col-12 col-md-7">
       <div class="cat-photos">
         <% if !@cat.photos.attached? %>
         <%= image_tag ["blue-cat.png", "pink-cat.png"].sample, class: "only-photo" %>
@@ -28,13 +28,13 @@
       </div>
       <div class="cat-info">
         <div class="row">
-          <div class="col-8">
+          <div class="col-7">
            <ul>
              <li><i class="fas fa-cat"></i><%= @cat.breed %>, <%= "#{@cat.color}, poil #{@cat.hair_length}"%></li>
              <li><i class="fas fa-birthday-cake"></i><%= "#{@cat.age} an#{"s" if @cat.age > 1}" %></li>
            </ul>
           </div>
-          <div class="col-4">
+          <div class="col-5">
            <ul>
              <li>
               <i class="fas fa-<%= @cat.gender == "femelle" ? "venus" : "mars" %>"></i>
@@ -46,7 +46,7 @@
         </div>
       </div>
     </div>
-    <div class="col-12 col-md-6">
+    <div class="col-12 col-md-5">
       <div class="owner-info">
         <p class="mb-0"><i class="fas fa-user"></i>Ce chat appartient à <%= @cat.user.first_name %></p>
         <p class="mb-0"><i class="fas fa-map-marker-alt"></i>Vous pourrez le récupérer à <%= @cat.city %></p>

--- a/app/views/components/_cats_card.html.erb
+++ b/app/views/components/_cats_card.html.erb
@@ -1,6 +1,6 @@
 <!-- card ===================================== -->
       <div class="card-cat" data-city="<%= cat.city %>">
-        <%= cl_image_tag cat.photos.first.key %>
+        <%= cl_image_tag cat.photos.first.key if cat.photos.attached? %>
         <div class="card-cat-infos">
           <div class="card-content">
             <h2><%= cat.name  %></h2>


### PR DESCRIPTION
- Ajout d'icônes pour les infos du proprio
<img width="952" alt="Capture d’écran 2021-02-18 à 23 27 44" src="https://user-images.githubusercontent.com/8093761/108434656-54273700-7248-11eb-881e-d7b75e39101e.png">

- Alignement du lien retour en arrière
<img width="486" alt="Capture d’écran 2021-02-18 à 23 26 57" src="https://user-images.githubusercontent.com/8093761/108434689-60ab8f80-7248-11eb-9ba3-cd759ec584c0.png">

- Image full size si pas de miniature (i.e. pas de 2e photo)
<img width="947" alt="Capture d’écran 2021-02-18 à 23 22 42" src="https://user-images.githubusercontent.com/8093761/108434741-74ef8c80-7248-11eb-93c5-d8e56cbda68d.png">

- Ajout d'icônes / refacto des infos du chat + gestion du genre et pluriel des années
<img width="657" alt="Capture d’écran 2021-02-19 à 00 22 26" src="https://user-images.githubusercontent.com/8093761/108434871-a5cfc180-7248-11eb-86d5-a0c468a0148b.png">

- Mise en place du switch des photo par clic (js)